### PR TITLE
 feat(notification): 10分TTLの新着通知（Solid Cache＋ActionCable）実装

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+# Procfile.dev
+api: cd backend && bin/rails s -p 3000
+front: cd frontend && yarn dev -p 3001

--- a/backend/app/channels/application_cable/connection.rb
+++ b/backend/app/channels/application_cable/connection.rb
@@ -1,4 +1,12 @@
+# frozen_string_literal: true
+
 module ApplicationCable
   class Connection < ActionCable::Connection::Base
+    identified_by :user_id
+
+    def connect
+      self.user_id = request.params["user_id"]&.to_i
+      reject_unauthorized_connection unless user_id.present?
+    end
   end
 end

--- a/backend/app/channels/notifications_channel.rb
+++ b/backend/app/channels/notifications_channel.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class NotificationsChannel < ApplicationCable::Channel
+  def subscribed
+    # ← ここで current_user は使わない
+    reject unless connection.user_id
+
+    stream_from stream_name
+
+    # 接続直後に直近10分の backlog を古い→新しい順で送信
+    backlog = NotificationCache.fetch_backlog(connection.user_id)
+    backlog.sort_by { |p| p['at'] || p[:at] }.each { |payload| transmit(payload) } if backlog.present?
+  end
+
+  private
+
+  def stream_name
+    "notif:#{connection.user_id}"
+  end
+end

--- a/backend/app/controllers/api/notifications_controller.rb
+++ b/backend/app/controllers/api/notifications_controller.rb
@@ -1,0 +1,17 @@
+# app/controllers/api/notifications_controller.rb
+class Api::NotificationsController < ApplicationController
+  before_action :require_user! # 認証の都合に合わせて適宜
+
+  def create
+    NotificationService.push_to(
+      user_id: current_user.id,
+      payload: {
+        title: params[:title] || "通知",
+        body:  params[:body]  || "テスト通知です",
+        kind:  params[:kind]  || "test",
+        url:   params[:url]
+      }
+    )
+    head :ok
+  end
+end

--- a/backend/app/controllers/api/notifications_debug_controller.rb
+++ b/backend/app/controllers/api/notifications_debug_controller.rb
@@ -1,0 +1,23 @@
+class Api::NotificationsDebugController < ApplicationController
+  before_action :ensure_development!
+
+  def create
+    uid = (params[:user_id].presence || 1).to_i
+    ttl = Integer(params[:ttl_seconds], exception: false) # ← 追加
+
+    payload = {
+      'kind'  => params[:kind]  || 'invite',
+      'title' => params[:title] || 'テスト通知',
+      'body'  => params[:body]  || 'これはテストです'
+    }
+
+    # ↓ ttl_seconds を渡す
+    item = NotificationFanout.push(uid, payload, ttl_seconds: ttl)
+    render json: { ok: item.present?, item: item }, status: :ok
+  end
+
+  private
+  def ensure_development!
+    head :forbidden unless Rails.env.development?
+  end
+end

--- a/backend/app/services/notification_cache.rb
+++ b/backend/app/services/notification_cache.rb
@@ -1,0 +1,88 @@
+# backend/app/services/notification_cache.rb
+# frozen_string_literal: true
+
+class NotificationCache
+  # --- 安全に ENV 数値を読む小ヘルパ ---
+  def self.read_env_positive_int(name, default)
+    raw = ENV[name]
+    val = Integer(raw, exception: false) # 無効なら nil
+    val && val > 0 ? val : default
+  end
+  private_class_method :read_env_positive_int
+
+  # ===== 可変TTL（開発検証用） =====
+  SECONDS   = read_env_positive_int("NOTIF_TTL_SECONDS", 600) # 10分=600
+  INDEX_TTL = SECONDS.seconds
+  ITEM_TTL  = SECONDS.seconds
+
+  # 索引の最大保持件数（暴走防止）
+  INDEX_MAX = read_env_positive_int("NOTIF_INDEX_MAX", 200)
+
+  class << self
+    # 通知を保存し、索引を更新して key を返す
+    def write_and_index(user_id, payload, ttl_seconds: nil)
+      key = build_item_key(user_id)
+      now = Time.current
+      id  = key.split(':').last
+
+      ttl = begin
+        v = Integer(ttl_seconds, exception: false)
+        v && v > 0 ? v.seconds : ITEM_TTL
+      end
+
+      Rails.cache.write(
+    key,
+    payload.merge(
+      'id'        => id,
+      'at'        => now.iso8601,
+      'saved_at'  => now,
+      'ttl'       => ttl.to_i,                      # ← 追加: 秒
+      'expire_at' => (now + ttl).iso8601            # ← 追加: 絶対時刻
+    ),
+        expires_in: ttl
+      )
+
+      index_key = build_index_key(user_id)
+      index = Rails.cache.read(index_key) || []
+      index << { 'key' => key, 'exp' => ttl.from_now }
+      index = prune(index)
+      # 索引のTTLは項目のTTLより長くならないようにする
+      Rails.cache.write(index_key, index, expires_in: [INDEX_TTL, ttl].min)
+
+      key
+    end
+
+    # 直近TTL内の通知をまとめて取得
+    def fetch_backlog(user_id)
+      index_key = build_index_key(user_id)
+      index = Rails.cache.read(index_key) || []
+      valid = prune(index)
+      keys  = valid.map { |e| e['key'] }
+
+      payloads =
+        if keys.empty?
+          []
+        else
+          Rails.cache.read_multi(*keys).values.compact
+        end
+
+      Rails.cache.write(index_key, valid, expires_in: INDEX_TTL)
+      payloads
+    end
+
+    private
+
+    def prune(index)
+      now = Time.current
+      index.select { |e| e['exp'] > now }.last(INDEX_MAX)
+    end
+
+    def build_index_key(user_id)
+      "notif:index:#{user_id}"
+    end
+
+    def build_item_key(user_id)
+      "notif:item:#{user_id}:#{SecureRandom.uuid}"
+    end
+  end
+end

--- a/backend/app/services/notification_fanout.rb
+++ b/backend/app/services/notification_fanout.rb
@@ -1,0 +1,16 @@
+# backend/app/services/notification_fanout.rb
+# frozen_string_literal: true
+
+class NotificationFanout
+  def self.push(user_id, payload, ttl_seconds: nil)
+    key  = NotificationCache.write_and_index(user_id, payload, ttl_seconds: ttl_seconds) # ← 渡す
+    item = Rails.cache.read(key)
+    ActionCable.server.broadcast("notif:#{user_id}", item) if item
+    item
+  end
+
+  def self.stream_name(user_id)
+    "notif:#{user_id}"
+  end
+  private_class_method :stream_name
+end

--- a/backend/app/services/notification_service.rb
+++ b/backend/app/services/notification_service.rb
@@ -1,0 +1,14 @@
+# app/services/notification_service.rb
+class NotificationService
+  STREAM_PREFIX = "notif:"
+
+  # payload 例:
+  # { title: "新着メッセージ", body: "〇〇さんから…", kind: "message", url: "/inbox/..." }
+  def self.push_to(user_id:, payload:)
+    # 1) Cache に保存（TTL 10分 & index）
+    NotificationCache.write_and_index(user_id, payload)
+
+    # 2) Push 配信
+    ActionCable.server.broadcast("#{STREAM_PREFIX}#{user_id}", payload)
+  end
+end

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -69,6 +69,8 @@ Rails.application.configure do
   # config.generators.apply_rubocop_autocorrect_after_generate!
 
   # 既存設定は省略
+  config.action_cable.mount_path = '/cable'
+  config.action_cable.disable_request_forgery_protection = true
   config.action_cable.allowed_request_origins = [
     "http://localhost:8000",
     "http://127.0.0.1:8000",

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -10,4 +10,9 @@ Rails.application.routes.draw do
 
   # 他のAPIルートは省略
   mount ActionCable.server => "/cable"
+
+  namespace :api do
+    resources :notifications, only: :create
+  post "notifications/debug", to: "notifications_debug#create"
+  end
 end

--- a/frontend/src/app/hooks/useNotifications.ts
+++ b/frontend/src/app/hooks/useNotifications.ts
@@ -1,0 +1,128 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+/* cspell:disable-next-line */
+import type { Channel } from '@rails/actioncable'
+import { getConsumer } from '@/lib/cable'
+
+export type NotificationPayload = {
+  id?: string
+  title: string
+  body?: string
+  kind?: string
+  url?: string
+  at?: string          // ISO
+  saved_at?: string    // ISO
+  ttl?: number         // 秒（サーバ付与）
+  expire_at?: string   // ISO（サーバ付与）
+}
+
+export function useNotifications(userId?: number | string) {
+  const [list, setList] = useState<NotificationPayload[]>([])
+  const subRef = useRef<Channel | null>(null)
+  const timersRef = useRef<Map<string, number>>(new Map())
+
+  useEffect(() => {
+    const consumer = userId == null ? getConsumer() : getConsumer(userId)
+
+    const ensureId = (n: NotificationPayload) =>
+      n.id ?? `${n.title}:${n.body ?? ''}:${n.at ?? ''}`
+
+    const ensureAt = (n: NotificationPayload) =>
+      n.at ?? new Date().toISOString()
+
+    const isExpired = (n: NotificationPayload, nowMs: number) => {
+      const atMs = n.at ? new Date(n.at).getTime() : nowMs
+      const expMs = n.expire_at
+        ? new Date(n.expire_at).getTime()
+        : n.ttl
+          ? atMs + n.ttl * 1000
+          : undefined
+      return expMs !== undefined && expMs <= nowMs
+    }
+
+    const armTimer = (n: NotificationPayload) => {
+      const id = ensureId(n)
+      const atMs = n.at ? new Date(n.at).getTime() : Date.now()
+      const expMs = n.expire_at
+        ? new Date(n.expire_at).getTime()
+        : n.ttl
+          ? atMs + n.ttl * 1000
+          : undefined
+      if (expMs === undefined) return
+
+      const delay = Math.max(0, expMs - Date.now())
+
+      const prev = timersRef.current.get(id)
+      if (prev) window.clearTimeout(prev)
+
+      if (delay === 0) {
+        setList(prev => prev.filter(x => ensureId(x) !== id))
+        timersRef.current.delete(id)
+        return
+      }
+
+      const t = window.setTimeout(() => {
+        setList(prev => prev.filter(x => ensureId(x) !== id))
+        timersRef.current.delete(id)
+      }, delay)
+      timersRef.current.set(id, t)
+    }
+
+    const sweep = () => {
+      const now = Date.now()
+      setList(prev => prev.filter(n => !isExpired(n, now)))
+    }
+
+    const sub = consumer.subscriptions.create(
+      { channel: 'NotificationsChannel' },
+      {
+        received(raw: unknown) {
+          const data = raw as NotificationPayload
+          const filled: NotificationPayload = {
+            ...data,
+            id: ensureId(data),
+            at: ensureAt(data),
+          }
+
+          console.log('[Cable] received', filled) // ← 受信ログ（切り分け用）
+
+          setList(prev => {
+            const map = new Map(prev.map(x => [ensureId(x), x]))
+            map.set(ensureId(filled), filled)
+            return Array.from(map.values())
+              .sort((a, b) => (+new Date(b.at ?? 0)) - (+new Date(a.at ?? 0)))
+              .slice(0, 100)
+          })
+
+          if (isExpired(filled, Date.now())) {
+            setList(prev => prev.filter(n => ensureId(n) !== ensureId(filled)))
+          } else {
+            armTimer(filled)
+          }
+        },
+        connected() { /* console.debug('[Cable] connected') */ },
+        disconnected() { /* console.debug('[Cable] disconnected') */ },
+      },
+    )
+
+    subRef.current = sub
+
+    const interval = window.setInterval(sweep, 5000)
+    const onVis = () => document.visibilityState === 'visible' && sweep()
+    document.addEventListener('visibilitychange', onVis)
+
+    return () => {
+      const timers = timersRef.current
+      subRef.current?.unsubscribe?.()
+      window.clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVis)
+      timers.forEach(id => window.clearTimeout(id))
+      timersRef.current.clear()
+      subRef.current = null
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []) // getConsumer は初回で URL が固定されるため依存は空でOK
+
+  return { notifications: list }
+}

--- a/frontend/src/app/notifications/page.tsx
+++ b/frontend/src/app/notifications/page.tsx
@@ -1,0 +1,87 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { useNotifications, type NotificationPayload } from '@/app/hooks/useNotifications'
+
+export default function NotificationsPage() {
+  const { notifications } = useNotifications()
+  const [now, setNow] = useState(() => Date.now())
+
+  // 1秒ごとに再描画（カウントダウン更新）
+  useEffect(() => {
+    const t = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(t)
+  }, [])
+
+  const remainingSeconds = (n: NotificationPayload) => {
+    const atMs = n.at ? new Date(n.at).getTime() : now
+    const expMs = n.expire_at
+      ? new Date(n.expire_at).getTime()
+      : n.ttl
+        ? atMs + n.ttl * 1000
+        : undefined
+    if (expMs === undefined) return null
+    return Math.max(0, Math.ceil((expMs - now) / 1000))
+  }
+
+  return (
+    <main className="mx-auto max-w-xl p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Notifications (TTL 表示)</h1>
+      <p className="text-sm text-muted-foreground">
+        サーバは <code>ttl</code> / <code>expire_at</code> を付与。フロントはそれに従って自動消滅＆カウントダウン。
+      </p>
+
+      <ul className="space-y-3">
+        {notifications.length === 0 && (
+          <li className="text-sm opacity-70">（通知待ち）</li>
+        )}
+
+        {notifications.map((n, i) => {
+          const remain = remainingSeconds(n)
+          return (
+            <li key={n.id ?? i} className="rounded-xl border p-4">
+              <div className="font-semibold">{n.title}</div>
+              {n.body && <div className="text-sm mt-1">{n.body}</div>}
+
+              <div className="text-xs opacity-60 mt-2 space-y-1">
+                <div>
+                  kind: {n.kind ?? '—'}
+                  {n.saved_at && <> • saved_at: {n.saved_at}</>}
+                </div>
+                {(n.expire_at || n.ttl) && (
+                  <div>
+                    {n.expire_at ? <>expire_at: {n.expire_at}</> : <>ttl: {n.ttl}s</>}
+                    {remain !== null && <> • 残り {remain} 秒</>}
+                  </div>
+                )}
+              </div>
+
+              {n.url && (
+                <div className="mt-2">
+                  <Link href={n.url} className="text-blue-600 underline">
+                    開く
+                  </Link>
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+
+      {/* データの生表示（切り分け用） */}
+      <div className="mt-6">
+        <h2 className="text-sm font-semibold">Raw payloads</h2>
+  <pre
+    className="
+      text-xs rounded-md border overflow-auto p-3
+      bg-gray-50 text-gray-900 border-gray-200
+      dark:bg-zinc-900 dark:text-zinc-100 dark:border-zinc-800
+    "
+  >
+          {JSON.stringify(notifications, null, 2)}
+        </pre>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/lib/cable.ts
+++ b/frontend/src/lib/cable.ts
@@ -6,12 +6,17 @@ import * as ActionCable from '@rails/actioncable'
  */
 let consumer: ActionCable.Cable | null = null
 
-export function getConsumer() {
+export function getConsumer(userId: number | string = 1) {
   if (consumer) return consumer
-  const url = process.env.NEXT_PUBLIC_WS_URL
-  if (!url) {
+
+  const baseUrl = process.env.NEXT_PUBLIC_WS_URL
+  if (!baseUrl) {
     throw new Error('NEXT_PUBLIC_WS_URL is not set')
   }
+
+  // 開発用: URL に ?user_id=xx を付加
+  const url = `${baseUrl}?user_id=${encodeURIComponent(userId)}`
+
   consumer = ActionCable.createConsumer(url)
   return consumer
 }


### PR DESCRIPTION
## 🧾 概要
- **Solid Cache**（`Rails.cache`）で通知を **TTL付き一時保存**（デフォルト10分）。  
- **ActionCable** 経由で push 配信し、**再接続時に直近TTL内の通知を復元**。  
- **フロント**では `useNotifications` フックで受信・重複排除・自動消滅（TTL）・**カウントダウン表示**を実装。  
- **開発用デバッグAPI**（`POST /api/notifications/debug`）と **Procfile.dev** を追加。  

---

## 🔄 変更点（ファイル別）

### Backend
- `backend/app/channels/application_cable/connection.rb`
  - ActionCable接続時に `?user_id=` クエリから `identified_by :user_id` を確立、未指定なら拒否。
- `backend/app/channels/notifications_channel.rb`
  - `notif:<user_id>` へストリーム。接続直後に **直近TTLのバックログ**を古い→新しい順で `transmit`。
- `backend/app/controllers/api/notifications_controller.rb`
  - 認証済みユーザ向けの通知作成エンドポイント（サービス呼び出しの雛形）。
- `backend/app/controllers/api/notifications_debug_controller.rb`
  - **開発専用**のデバッグ用POST。`user_id` と `ttl_seconds` を指定して送信テスト可能。
- `backend/app/services/notification_cache.rb`
  - Solid Cache へ通知本体を `expires_in` で保存し、**インデックス**も維持。  
  - `ttl` と `expire_at` をペイロードへ付与。環境変数でTTL変更可。  
- `backend/app/services/notification_fanout.rb`
  - 保存＋インデックス更新後のペイロードを **ActionCable broadcast**。
- `backend/app/services/notification_service.rb`
  - 既存/将来のサービスから呼べる簡易API（雛形）。
- `backend/config/environments/development.rb`
  - `/cable` を mount、CSRF無効化（devのみ）、allowed origins 調整。
- `backend/config/routes.rb`
  - `mount ActionCable.server => '/cable'`  
  - `POST /api/notifications` / `POST /api/notifications/debug` を追加。

### Frontend
- `frontend/src/lib/cable.ts`
  - `getConsumer(userId=1)`：**初回**接続URLに `?user_id=xxx` を付与（開発用）。
- `frontend/src/app/hooks/useNotifications.ts`
  - **受信・重複排除・自動消滅・5秒スイープ・タブ復帰スイープ**の堅牢フック。  
  - `NotificationPayload` 型（`ttl`/`expire_at`/`saved_at` 等を包含）。
- `frontend/src/app/notifications/page.tsx`
  - 通知のリスト表示＋**残り秒数カウントダウン**。  
  - 画面下部に **Raw payloads（生JSON）** をライト/ダーク両対応で表示（切り分け用）。

### DevOps
- `Procfile.dev`
  - `api`（Rails 3000）/ `front`（Next 3001）を foreman/overmind で同時起動。

---

## 🎯 目的
- **A（Solid）構成**のまま、**一定時間（例: 10分 or 10秒）だけ表示される新着通知**を MVP として提供。  
- ブラウザ再接続時は **直近TTL内のみを復元**。TTL切れは復元しない。

---

## ⚙️ 環境変数

| 変数                | 既定 | 説明 |
|---------------------|------|------|
| `NOTIF_TTL_SECONDS` | 600  | 通知TTL（秒）。開発検証で短縮可（例: 10）。 |
| `NOTIF_INDEX_MAX`   | 200  | インデックス上限数（暴走防止）。 |

**Frontend**:  
`.env.local`  
```env
NEXT_PUBLIC_WS_URL=ws://localhost:3000/cable
```

## 🧪 動作確認手順（ローカル）

### 起動
```bash
# ルートで
overmind s -f Procfile.dev   # or: foreman start -f Procfile.dev
```

## WebSocket確認（任意）
```bash
wscat -c "ws://localhost:3000/cable?user_id=1"
# => welcome / ping が見えればOK
```

## 受信ページ
- http://localhost:3001/notifications を開く
- 下部の Raw payloads にもデータが出ることを確認（ダークモードでも視認可能）

## デバッグ送信（TTL 10秒）
```bash
curl -X POST http://localhost:3000/api/notifications/debug \
  -H "Content-Type: application/json" \
  -d '{"user_id":1,"title":"TTL10秒","body":"10秒で消えます","ttl_seconds":10}'
```
- 即座に1件表示され、カウントダウンが進み10秒前後で自動消滅
- ページをリロードすると TTL内のものだけが復元 される

## ✅ テスト観点（チェックリスト）
- [ ] WebSocket 接続が正常に確立される  
- [ ] `/notifications` ページに通知が表示される  
- [ ] `ttl_seconds` 付き通知が指定時間後にフロントから消える  
- [ ] ページを再読み込みすると未期限切れの通知だけが復元される  
- [ ] 複数通知を送った場合、最新順に並んで表示される  
- [ ] ダークモードでも Raw payloads が視認可能である  

---

## 📸 スクリーンショット（任意）
- 動作中の画面を貼り付けてください  

---

## 📦 コミット粒度
- **chore(cable):** ActionCable 接続まわり (`connection.rb`, `cable.ts`)  
- **chore(config):** `/cable` mount & 開発環境設定 (`routes.rb`, `development.rb`)  
- **feat(notification):** 通知チャンネル・サービス・hook/page 実装  
- **chore(dev):** Procfile.dev 追加  

---

## 🔀 ブランチ
`feature/issue4-notification-mvp-solid`
